### PR TITLE
Fixed bug with identifying IPython processes

### DIFF
--- a/nbtop/main.py
+++ b/nbtop/main.py
@@ -30,7 +30,7 @@ def notebook_process(process):
     """
     Is the process an IPython notebook process
     """
-    if process.name() == 'python':
+    if 'python' in process.name():
         for arg in process.cmdline():
             if arg.endswith('.json') and '/kernel-' in arg:
                 return True


### PR DESCRIPTION
In some situations (Python 3, I think), the IPython processes actually run with
a name of 'ipython' not 'python', so weren't picked up by the process filtering
code. This meant that CPU and MEM were both coming up as -99. This fixes that.
