### PR TITLE
Fixed issue where memory/CPU weren't reported on OS X

### DIFF
--- a/nbtop/main.py
+++ b/nbtop/main.py
@@ -30,7 +30,7 @@ def notebook_process(process):
     """
     Is the process an IPython notebook process
     """
-    if 'python' in process.name():
+    if 'python' in process.name().lower():
         for arg in process.cmdline():
             if arg.endswith('.json') and '/kernel-' in arg:
                 return True


### PR DESCRIPTION
It seems that for some installs of Python on OS X, the actual process that is run
when you start notebook kernels is called `Python` not `python`.

Converting the process name to lowercase before checking fixes this.
